### PR TITLE
Fix logUpdate.clear()

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,18 +8,18 @@ function main(stream) {
 	var render = function () {
 		cliCursor.hide();
 		var out = [].join.call(arguments, ' ') + '\n';
-		stream.write(ansiEscapes.eraseLines(prevLineCount) + out);
+		render.clear();
+		stream.write(out);
 		prevLineCount = out.split('\n').length;
 	};
 
 	render.clear = function () {
+		stream.write(ansiEscapes.eraseLines(prevLineCount));
 		prevLineCount = 0;
-		stream.write(ansiEscapes.eraseLines(prevLineCount + 1));
 	};
 
 	render.done = function () {
 		prevLineCount = 0;
-		stream.write('\n');
 	};
 
 	return render;

--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ function main(stream) {
 	var render = function () {
 		cliCursor.hide();
 		var out = [].join.call(arguments, ' ') + '\n';
-		render.clear();
-		stream.write(out);
+		stream.write(ansiEscapes.eraseLines(prevLineCount) + out);
 		prevLineCount = out.split('\n').length;
 	};
 


### PR DESCRIPTION
This commit fixes `render.clear` and resolves #4.

Also removed `stream.write('\n');` from `render.done`, because it adds an extra empty line (the output in render already includes `\n`, so the caret is already on the next line).