### PR TITLE
Add an option to show/hide cursor

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,18 @@ const ansiEscapes = require('ansi-escapes');
 const cliCursor = require('cli-cursor');
 const wrapAnsi = require('wrap-ansi');
 
-const main = stream => {
+const main = (stream, options) => {
+	options = Object.assign({
+		showCursor: false
+	}, options);
+
 	let prevLineCount = 0;
 
 	const render = function () {
-		cliCursor.hide();
+		if (!options.showCursor) {
+			cliCursor.hide();
+		}
+
 		let out = [].join.call(arguments, ' ') + '\n';
 		out = wrapAnsi(out, process.stdout.columns || 80, {wordWrap: false, trim: false, hard: true});
 		stream.write(ansiEscapes.eraseLines(prevLineCount) + out);
@@ -21,7 +28,10 @@ const main = stream => {
 
 	render.done = () => {
 		prevLineCount = 0;
-		cliCursor.show();
+
+		if (!options.showCursor) {
+			cliCursor.show();
+		}
 	};
 
 	return render;

--- a/readme.md
+++ b/readme.md
@@ -56,9 +56,18 @@ Log to stderr.
 ### logUpdate.stderr.clear()
 ### logUpdate.stderr.done()
 
-### logUpdate.create(stream)
+### logUpdate.create(stream, options)
 
 Get a `logUpdate` method that logs to the specified stream.
+Additionally, `logUpdate.create()` method accepts `showCursor` option, which determines whether to show a cursor or not. By default, the cursor is hidden.
+Showing a cursor is useful when a CLI accepts input from a user.
+
+```js
+// Write output, but don't hide a cursor
+const log = logUpdate.create(process.stdout, {
+	showCursor: true
+});
+```
 
 
 ## Examples

--- a/readme.md
+++ b/readme.md
@@ -56,14 +56,23 @@ Log to stderr.
 ### logUpdate.stderr.clear()
 ### logUpdate.stderr.done()
 
-### logUpdate.create(stream, options)
+### logUpdate.create(stream, [options])
 
 Get a `logUpdate` method that logs to the specified stream.
-Additionally, `logUpdate.create()` method accepts `showCursor` option, which determines whether to show a cursor or not. By default, the cursor is hidden.
-Showing a cursor is useful when a CLI accepts input from a user.
+
+#### options
+
+Type: `Object`
+
+##### showCursor
+
+Type: `boolean`<br>
+Default: `false`
+
+Show the cursor. This can be useful when a CLI accepts input from a user.
 
 ```js
-// Write output, but don't hide a cursor
+// Write output but don't hide the cursor
 const log = logUpdate.create(process.stdout, {
 	showCursor: true
 });


### PR DESCRIPTION
This PR adds `options` argument to `logUpdate.create()` with `showCursor` option (defaults to `false`, so that behavior is the same as before).

Showing a cursor is useful when a CLI accepts user input, but it still needs to use `log-update` for output.

P.S. I found out that there are no actual tests here, should I open an issue about that or this is intentional?