### PR TITLE
feat: erase only changed lines from the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "ansi-escapes": "^3.0.0",
     "cli-cursor": "^2.0.0",
+    "split-lines": "^1.1.0",
     "wrap-ansi": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As I mentioned in #25, in some terminals there is noticeable flickering when a lot of lines are updated. My initial suggestion was to update only the changed lines but @sindresorhus said that would be slow. I agree with that. This solution is about erasing only that part of the previous output which has been changed by the new output.

The number of cursor manipulations is the same but the number of lines that are erased is less.

However, this also adds more CPU work because the prev lines are compared to the new lines. Hence, I will totally understand if this solution will get rejected.

If you think this would cause performance issues, a compromise might be to only use this approach when the outputs are less than X lines.