### PR TITLE
Remove Node.js v4.x from test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'


### PR DESCRIPTION
Hello @sindresorhus. Thanks for great libraries that you've created.

This PR removes Node.js v4.x from test targets since Node.js 4.x went into its End of Life. Besides, this project's test in CI keeps failing due to a version incompatibility (maybe).

failed tests: https://travis-ci.org/sindresorhus/log-update/jobs/367053134

refs: https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742