### PR TITLE
TypeScript definition - Use `WritableStream` instead of `stream.Writable`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="node"/>
-import {Writable as WritableStream} from 'stream';
 
 export interface LogUpdate {
 	(...text: string[]): void;
@@ -47,7 +46,7 @@ declare const logUpdate: LogUpdate & {
 	 *
 	 * @param stream - The stream to log to.
 	 */
-	readonly create: (stream: WritableStream, options?: Options) => LogUpdate;
+	readonly create: (stream: NodeJS.WritableStream, options?: Options) => LogUpdate;
 };
 
 export default logUpdate;


### PR DESCRIPTION
Thanks for adding TypeScript types to your modules! 

In Node typings, it is generally preferred to use the `WritableStream` interface when asking for a writable stream (not `stream.Writable`). This should allow people to use implementations of streams other than the built-in.

`Writable` itself implements the `WritableStream` interface: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/globals.d.ts#L612-L619

```ts
class Writable extends Stream implements NodeJS.WritableStream {
    ...
```

cc @BendingBender 