### PR TITLE
Update dependencies and update node target versions to current LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
   - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '13'
   - '12'
   - '10'
   - '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
+  - '13'
   - '12'
   - '10'
   - '8'
-  - '6'

--- a/index.js
+++ b/index.js
@@ -14,9 +14,10 @@ const getWidth = stream => {
 };
 
 const main = (stream, options) => {
-	options = Object.assign({
-		showCursor: false
-	}, options);
+	options = {
+		showCursor: false,
+		...options
+	};
 
 	let prevLineCount = 0;
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/package.json
+++ b/package.json
@@ -38,15 +38,15 @@
 		"animation"
 	],
 	"dependencies": {
-		"ansi-escapes": "^3.2.0",
-		"cli-cursor": "^2.1.0",
-		"wrap-ansi": "^5.0.0"
+		"ansi-escapes": "^4.3.0",
+		"cli-cursor": "^3.1.0",
+		"wrap-ansi": "^6.2.0"
 	},
 	"devDependencies": {
 		"@types/node": "^11.12.2",
-		"ava": "^1.4.1",
+		"ava": "^2.4.0",
 		"terminal.js": "^1.0.10",
-		"tsd": "^0.7.1",
-		"xo": "^0.24.0"
+		"tsd": "^0.11.0",
+		"xo": "^0.25.3"
 	}
 }


### PR DESCRIPTION
Update dependencies and replace node 6 test with node 12.

node 6 is out of life, see: https://nodejs.org/en/about/releases/

@sindresorhus i'm unsure if this should be tested against node 13 (non LTS version)