### PR TITLE
Skip render if the output is unchanged

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,11 +47,13 @@ const main = (stream, options) => {
 	render.clear = () => {
 		stream.write(ansiEscapes.eraseLines(prevLineCount));
 		prevOut = '';
+		prevWidth = getWidth(stream);
 		prevLineCount = 0;
 	};
 
 	render.done = () => {
 		prevOut = '';
+		prevWidth = getWidth(stream);
 		prevLineCount = 0;
 
 		if (!options.showCursor) {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const main = (stream, options) => {
 	}, options);
 
 	let prevLineCount = 0;
+	let prevOut = '';
 
 	const render = (...args) => {
 		if (!options.showCursor) {
@@ -26,6 +27,11 @@ const main = (stream, options) => {
 		}
 
 		let out = args.join(' ') + '\n';
+		if (out === prevOut) {
+			return;
+		}
+
+		prevOut = out;
 		out = wrapAnsi(out, getWidth(stream), {
 			trim: false,
 			hard: true,
@@ -37,10 +43,12 @@ const main = (stream, options) => {
 
 	render.clear = () => {
 		stream.write(ansiEscapes.eraseLines(prevLineCount));
+		prevOut = '';
 		prevLineCount = 0;
 	};
 
 	render.done = () => {
+		prevOut = '';
 		prevLineCount = 0;
 
 		if (!options.showCursor) {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const main = (stream, options) => {
 	}, options);
 
 	let prevLineCount = 0;
+	let prevWidth = getWidth(stream);
 	let prevOut = '';
 
 	const render = (...args) => {
@@ -27,12 +28,14 @@ const main = (stream, options) => {
 		}
 
 		let out = args.join(' ') + '\n';
-		if (out === prevOut) {
+		const width = getWidth(stream);
+		if (out === prevOut && prevWidth === width) {
 			return;
 		}
 
 		prevOut = out;
-		out = wrapAnsi(out, getWidth(stream), {
+		prevWidth = width;
+		out = wrapAnsi(out, width, {
 			trim: false,
 			hard: true,
 			wordWrap: false


### PR DESCRIPTION
Resolves #44 

Stores previous output and compares the current value to the previous value when rendering. If the values are the same, we bail out early to reduce the work that the consumer of the output stream does.