### PR TITLE
require() of ES Module not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-update-async-hook",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "log-update fork that uses async-exit-hook internally",
   "license": "MIT",
   "repository": "AndreyBelym/log-update-async-hook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-update-async-hook",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "log-update fork that uses async-exit-hook internally",
   "license": "MIT",
   "repository": "AndreyBelym/log-update-async-hook",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-update-async-hook",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "log-update fork that uses async-exit-hook internally",
   "license": "MIT",
   "repository": "AndreyBelym/log-update-async-hook",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,24 @@
 {
-  "name": "log-update",
-  "version": "2.0.0",
-  "description": "Log by overwriting the previous output in the terminal. Useful for rendering progress bars, animations, etc.",
+  "name": "log-update-async-hook",
+  "version": "2.0.2",
+  "description": "log-update fork that uses async-exit-hook internally",
   "license": "MIT",
-  "repository": "sindresorhus/log-update",
+  "repository": "AndreyBelym/log-update-async-hook",
   "author": {
+    "name": "Andrey Belym",
+    "email": "belym.a.2105@gmail.com"
+  },
+  "contributors": [{
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com"
-  },
-  "engines": {
-    "node": ">=4"
-  },
+  }],
   "scripts": {
-    "test": "xo && node test.js"
+    "test": "node test.js"
   },
+  "main": "src/index.js",
   "files": [
-    "index.js"
+    "src"
   ],
   "keywords": [
     "log",
@@ -38,7 +40,8 @@
   ],
   "dependencies": {
     "ansi-escapes": "^2.0.0",
-    "cli-cursor": "^2.0.0",
+    "async-exit-hook": "^1.1.2",
+    "onetime": "^2.0.1",
     "wrap-ansi": "^2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-update-async-hook",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "log-update fork that uses async-exit-hook internally",
   "license": "MIT",
   "repository": "AndreyBelym/log-update-async-hook",
@@ -8,11 +8,13 @@
     "name": "Andrey Belym",
     "email": "belym.a.2105@gmail.com"
   },
-  "contributors": [{
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  }],
+  "contributors": [
+    {
+      "name": "Sindre Sorhus",
+      "email": "sindresorhus@gmail.com",
+      "url": "sindresorhus.com"
+    }
+  ],
   "scripts": {
     "test": "node test.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
-# log-update [![Build Status](https://travis-ci.org/sindresorhus/log-update.svg?branch=master)](https://travis-ci.org/sindresorhus/log-update)
+# log-update-async-hook [![Build Status](https://travis-ci.org/AndreyBelym/log-update-async-hook.svg?branch=master)](https://travis-ci.org/AndreyBelym/log-update-async-hook)
 
+This is a fork of the [log-update](https://github.com/sindresorhus/log-update) by Sindre Sorhus, that uses `async-exit-hook` to restore terminal cursor state when the process terminates.
+Usage of `exit-hook` or `signal-exit` hook in the original `log-update` prevents execution of asynchronous operations on signals (`SIGTERM`, `SIGHUP`, etc.) in the code of the main application.
+So I've replaced them by `async-exit-hook`, rewritten code to allow execution on Node versions below `4.x` and bundled some dependencies into the package.
+  
 > Log by overwriting the previous output in the terminal.<br>
 > Useful for rendering progress bars, animations, etc.
 

--- a/src/cli-cursor.js
+++ b/src/cli-cursor.js
@@ -1,0 +1,39 @@
+'use strict';
+var restoreCursor = require('./restore-cursor');
+
+var hidden = false;
+
+exports.show = function (stream) {
+	var s = stream || process.stderr;
+
+	if (!s.isTTY) {
+		return;
+	}
+
+	hidden = false;
+	s.write('\u001b[?25h');
+};
+
+exports.hide = function (stream) {
+	var s = stream || process.stderr;
+
+	if (!s.isTTY) {
+		return;
+	}
+
+	restoreCursor();
+	hidden = true;
+	s.write('\u001b[?25l');
+};
+
+exports.toggle = function (force, stream) {
+	if (force !== undefined) {
+		hidden = force;
+	}
+
+	if (hidden) {
+		exports.show(stream);
+	} else {
+		exports.hide(stream);
+	}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,31 +1,32 @@
 'use strict';
-const ansiEscapes = require('ansi-escapes');
-const cliCursor = require('cli-cursor');
-const wrapAnsi = require('wrap-ansi');
+var ansiEscapes = require('ansi-escapes');
+var wrapAnsi = require('wrap-ansi');
+var cliCursor = require('./cli-cursor');
 
-const main = stream => {
-	let prevLineCount = 0;
 
-	const render = function () {
+function main (stream) {
+	var prevLineCount = 0;
+
+	var render = function () {
 		cliCursor.hide();
-		let out = [].join.call(arguments, ' ') + '\n';
+		var out = [].join.call(arguments, ' ') + '\n';
 		out = wrapAnsi(out, process.stdout.columns || 80, {wordWrap: false});
 		stream.write(ansiEscapes.eraseLines(prevLineCount) + out);
 		prevLineCount = out.split('\n').length;
 	};
 
-	render.clear = () => {
+	render.clear = function () {
 		stream.write(ansiEscapes.eraseLines(prevLineCount));
 		prevLineCount = 0;
 	};
 
-	render.done = () => {
+	render.done = function () {
 		prevLineCount = 0;
 		cliCursor.show();
 	};
 
 	return render;
-};
+}
 
 module.exports = main(process.stdout);
 module.exports.stderr = main(process.stderr);

--- a/src/index.js
+++ b/src/index.js
@@ -7,21 +7,42 @@ var cliCursor = require('./cli-cursor');
 function main (stream) {
 	var prevLineCount = 0;
 
+	var streamWrite = stream.write;
+
+	var overridenWrite = function (...args) {
+		if (prevLineCount)
+			render.clear();
+
+		return streamWrite.apply(this, args);
+	};
+
 	var render = function () {
 		cliCursor.hide();
+
+		if (stream.write !== overridenWrite) {
+			streamWrite  = stream.write;
+			stream.write = overridenWrite
+		}
+		  
 		var out = [].join.call(arguments, ' ') + '\n';
+
 		out = wrapAnsi(out, process.stdout.columns || 80, {wordWrap: false});
-		stream.write(ansiEscapes.eraseLines(prevLineCount) + out);
+
+		streamWrite.call(stream, ansiEscapes.eraseLines(prevLineCount) + out);
+		
 		prevLineCount = out.split('\n').length;
 	};
 
 	render.clear = function () {
-		stream.write(ansiEscapes.eraseLines(prevLineCount));
+		streamWrite.call(stream, ansiEscapes.eraseLines(prevLineCount));
+
 		prevLineCount = 0;
 	};
 
 	render.done = function () {
 		prevLineCount = 0;
+		stream.write  = streamWrite;
+
 		cliCursor.show();
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function isStdStream (stream) {
 
 function main (stream) {
 	var prevLineCount = 0;
-	var context       = { stream };
+	var context       = { stream, streamWrite: stream.write };
 
 	function overriddenWrite (...args) {
 		if (prevLineCount)
@@ -22,10 +22,7 @@ function main (stream) {
 			return context.stdoutWrite.apply(this, args); 
 	};
 
-	function overrideStdStreams (context) {
-		if (!context.streamWrite && stream.write !== overriddenWrite)
-			context.streamWrite = context.stream.write;
-		
+	function overrideStdStreams (context) {	
 		if (!isStdStream(stream))
 			return context;
 

--- a/src/restore-cursor.js
+++ b/src/restore-cursor.js
@@ -1,0 +1,9 @@
+'use strict';
+var onetime  = require('onetime');
+var exitHook = require('async-exit-hook');
+
+module.exports = onetime(function () {
+	exitHook(function () {
+		process.stderr.write('\u001b[?25h');
+	});
+});

--- a/test.js
+++ b/test.js
@@ -17,6 +17,12 @@ const int = setInterval(() => {
 }, 100);
 
 setTimeout(logUpdate.done, 1000);
+
+setTimeout(() => {
+	console.log('some log');
+	console.error('some error');
+}, 2000);
+
 setTimeout(logUpdate.done, 3000);
 
 setTimeout(() => {


### PR DESCRIPTION
```
const logUpdate = require('log-update');
                  ^

Error [ERR_REQUIRE_ESM]: require() of ES Module C:\Users\ExpErgio\Desktop\cookrecetasbot\node_modules\log-update\index.js from C:\Users\ExpErgio\Desktop\cookrecetasbot\index.js not supported.
Instead change the require of C:\Users\ExpErgio\Desktop\cookrecetasbot\node_modules\log-update\index.js in C:\Users\ExpErgio\Desktop\cookrecetasbot\index.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (C:\Users\ExpErgio\Desktop\cookrecetasbot\index.js:2:19) {
  code: [32m'ERR_REQUIRE_ESM'[39m
}
```