### PR TITLE
Fix `fitTerminalHeight` is not working correctly with color text

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import ansiEscapes from 'ansi-escapes';
 import cliCursor from 'cli-cursor';
 import wrapAnsi from 'wrap-ansi';
 import sliceAnsi from 'slice-ansi';
+import stripAnsi from 'strip-ansi';
 
 const defaultTerminalHeight = 24;
 
@@ -27,8 +28,8 @@ const fitToTerminalHeight = (stream, text) => {
 
 	return sliceAnsi(
 		text,
-		lines.slice(0, toRemove).join('\n').length + 1,
-		text.length);
+		stripAnsi(lines.slice(0, toRemove).join('\n')).length + 1,
+	);
 };
 
 export function createLogUpdate(stream, {showCursor = false} = {}) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"ansi-escapes": "^5.0.0",
 		"cli-cursor": "^4.0.0",
 		"slice-ansi": "^5.0.0",
+		"strip-ansi": "^7.0.1",
 		"wrap-ansi": "^8.0.1"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -44,6 +44,24 @@ test('output beyond terminal height', t => {
 	t.is(terminal.state.getLine(2).str, '');
 });
 
+test('output beyond terminal height with color', t => {
+	const {terminal, log} = setup({rows: 3, columns: 20});
+
+	log('\u001B[32m√\u001B[39mline 1\nline 2\nline 3');
+	t.is(terminal.state.getLine(0).str, 'line 2');
+	t.is(terminal.state.getLine(1).str, 'line 3');
+	t.is(terminal.state.getLine(2).str, '');
+});
+
+test('output beyond terminal height with multi-line color', t => {
+	const {terminal, log} = setup({rows: 3, columns: 20});
+
+	log('\u001B[32m√line 1\nline 2\nline 3\u001B[39m');
+	t.is(terminal.state.getLine(0).str, 'line 2');
+	t.is(terminal.state.getLine(1).str, 'line 3');
+	t.is(terminal.state.getLine(2).str, '');
+});
+
 test('growing output', t => {
 	const {terminal, log} = setup({rows: 4, columns: 20});
 

--- a/test.js
+++ b/test.js
@@ -4,6 +4,8 @@ import {createLogUpdate} from './index.js';
 
 const setup = options => {
 	const terminal = new Terminal(options);
+	terminal.rows = options.rows;
+	terminal.columns = options.columns;
 	terminal.state.setMode('crlf', true);
 	const log = createLogUpdate(terminal);
 	return {terminal, log};


### PR DESCRIPTION
`fitTerminalHeight` was not returning correct value when a color text was passed.
Please see the tests I added for more details.
