### PR TITLE
update createLogUpdate example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,10 +71,10 @@ Default: `false`
 Show the cursor. This can be useful when a CLI accepts input from a user.
 
 ```js
-import logUpdate from 'log-update';
+import { createLogUpdate } from 'log-update';
 
 // Write output but don't hide the cursor
-const log = logUpdate.create(process.stdout, {
+const log = createLogUpdate(process.stdout, {
 	showCursor: true
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Default: `false`
 Show the cursor. This can be useful when a CLI accepts input from a user.
 
 ```js
-import { createLogUpdate } from 'log-update';
+import {createLogUpdate} from 'log-update';
 
 // Write output but don't hide the cursor
 const log = createLogUpdate(process.stdout, {


### PR DESCRIPTION
The example in the readme for `createLogUpdate` does not work as written. This adjusts the example for the named export of `createLogUpdate` which does work.